### PR TITLE
Added cheat sheet of GIacomo Tombolan

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ triennale-elettronica-polimi/
 │   ├── MEMS
 │   ├── Prerequisites
 │   ├── RFCircuitDesign
+│   ├── DICD
+│   ├── DESD
 │   └── SignalRecovery
 ├── 5
+│   ├── PowerElectronics
 │   └── EDFBI
 ├── TAB1
 │   ├── EMC

--- a/index.html
+++ b/index.html
@@ -399,6 +399,7 @@
   <li>Solutions of the tutorials by <i>Simone Guglielmino</i> - 
     <a href="https://github.com/valerionew/master-electronics-polimi/tree/master/4/SignalRecovery/TutorialsTranscripts" target="_blank">Folder</a> - 
     <a href="4/SignalRecovery/TutorialsTranscripts/SRTranscripts.zip" download>download</a> </li>
+    <li>Cheat sheet by <i>Giacomo Tombolan</i> - <a href="4/SignalRecovery/TOMBOLAN_SR_CHEAT_SHEET.pdf" download>download</a> </li>
 </ul>
 <h3 id="rf-circuit-design">RF Circuit Design</h3>
 <ul>


### PR DESCRIPTION
### Nuovo materiale:

- [x] Sto inserendo link a risorse esterne pubblicamente disponibili sotto rispettivi copyright 


I found this "cheat sheet" by Giacomo Tombolan in this repo (in the [4 folder](https://github.com/valerionew/triennale-elettronica-polimi/tree/master/4/SignalRecovery)), but there was not inserted in the html for download.

I also uploaded the README with latest pull requests.