### PR TITLE
Some fixes

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -37,7 +37,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.118.2
+      HUGO_VERSION: 0.119.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/content/_index.md
+++ b/content/_index.md
@@ -420,11 +420,9 @@ Extra
 =====
 
 🇮🇹 &nbsp;Gli appunti sono nella stessa lingua in cui viene erogato il corso.  
-👉 **(\*)** indica una risorsa esterna (sia al sito che alla repo Github).  
 ***Buono studio 💪***
 
 🇬🇧 &nbsp;The notes are in the same language in which the course is delivered.  
-👉 **(\*)** indicates an external resource (not hosted on the website or on the GitHub repository).  
 ***Good study 🤓***
 
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -279,13 +279,13 @@ First year
 
 *   Course notes by _Andrea Bertazzoni_ - [Download](4/Analog/AnalogCircuitDesign-Bertazzoni.pdf)
 *   Summaries for the oral exam by _Leonardo Sera_ (_questions 1-32_) - [Download](4/Analog/ACD_Summaries_Sera.pdf)
-*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1EHAdoGCdYNnAqupD2ju8tO2S0vs1d0OL)
+*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1EHAdoGCdYNnAqupD2ju8tO2S0vs1d0OL) **(\*)**
 *   Oral questions complete notes by _Giacomo Tombolan_ - [Download](4/Analog/AnalogCircuitDesign_TOMBOLAN.pdf)
 
 ### MEMS and Microsensors
 
 *   Course notes written in Latex by _Francesco Lenzi & Donato Carlo Giorgio_ - [Download](4/MEMS/MEMS_and_Microsensors.pdf)
-*   Course notes and formulary by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1rBTR7KC1rNfscHHJlDm7ZIyfFny1-2YM)
+*   Course notes and formulary by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1rBTR7KC1rNfscHHJlDm7ZIyfFny1-2YM) **(\*)**
 
 ### Electron Devices
 
@@ -295,19 +295,19 @@ First year
 
 *   Course notes by _Francesco Forestieri_ - [Theory](4/ElectronicSystems/ES_Theory_Forestieri.zip) - [Exercises](4/ElectronicSystems/ES_Exercises_Forestieri.zip)
 *   Course notes by _Luca Colombo_ - [Download](4/ElectronicSystems/ElectronicSystems.pdf)
-*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1RIdzefSzCJRy1k41KNpi7umDvHbOc3Cc)
+*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1RIdzefSzCJRy1k41KNpi7umDvHbOc3Cc) **(\*)**
 
 ### Signal Recovery
 
 *   Solutions of the tutorials by _Simone Guglielmino_ - [Folder](https://github.com/valerionew/triennale-elettronica-polimi/tree/master/static/4/SignalRecovery/TutorialsTranscripts) - [Download](4/SignalRecovery/TutorialsTranscripts/SRTranscripts.zip)
 *   Course notes by _Luca Colombo_ - [Download](4/SignalRecovery/SignalRecovery.pdf)
 *   Cheat sheet by _Giacomo Tombolan_ - [Download](4/SignalRecovery/TOMBOLAN_SR_CHEAT_SHEET.pdf)
-*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1oWAigQAJpLHzZl8WDYJxM7WvihO_sY8T)
+*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1oWAigQAJpLHzZl8WDYJxM7WvihO_sY8T) **(\*)**
 
 ### RF Circuit Design
 
 *   Course notes by _Andrea Bertazzoni_ - [Download](4/RFCircuitDesign/RFCircuitDesign-Bertazzoni.pdf)
-*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/15yBgF_jmEApOPBcul8NRNnyfJOv_r8J0)
+*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/15yBgF_jmEApOPBcul8NRNnyfJOv_r8J0) **(\*)**
 *   Oral questions complete notes by _Giacomo Tombolan_ - [Download](4/RFCircuitDesign/RadioFrequencyCircuitDesign_TOMBOLAN.pdf)
 ### Digital Integrated Circuit Design
 
@@ -320,8 +320,8 @@ First year
 
 ### Biochip
 
-*   Course notes on [Stduwiz](https://www.studwiz.com/notes/polimi/engineering/06-biomedical-engineering/subject-163/index.php) (add them to Prof's slides)
-*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/18qR8uuJGY1ekr2HxXgdR9YouXcNjTZnu)
+*   Course notes on [Stduwiz](https://www.studwiz.com/notes/polimi/engineering/06-biomedical-engineering/subject-163/index.php) (add them to Prof's slides) **(\*)**
+*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/18qR8uuJGY1ekr2HxXgdR9YouXcNjTZnu) **(\*)**
 
 &nbsp;
 
@@ -332,7 +332,7 @@ Second year
 
 ### Mixed-Signal Circuit Design
 
-*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1Dt6Us1RiZQkEG-8oJ6TgEohX7T3i1Dvi)
+*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1Dt6Us1RiZQkEG-8oJ6TgEohX7T3i1Dvi) **(\*)**
 *   Oral questions complete notes by _Giacomo Tombolan_ - [Download](5/MixedSignal/MixedSignalCircuitDesign_TOMBOLAN.pdf)
 ### Power Electronics
 
@@ -340,13 +340,13 @@ Second year
 
 ### Microelectronic Technologies
 
-*   Course notes by _Mikel Kumria_ - [Folder](https://drive.google.com/drive/folders/12AprM4BqPXh8qebSwoPI3FGgb9QD1zvW)
+*   Course notes by _Mikel Kumria_ - [Folder](https://drive.google.com/drive/folders/12AprM4BqPXh8qebSwoPI3FGgb9QD1zvW) **(\*)**
 
 ### Electronic Design For Biomedical Instrumentation
 
 *   Course notes by _Luca Colombo_ - [Download](5/EDFBI/ElectronicsDesign.pdf)
 *   Summary by _Matteo Toia_ - [Download](5/EDFBI/Summary_Toia.pdf)
-*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1N2Xk5plTNXJkXJJkuynDPz0x7fKjDf3L)
+*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1N2Xk5plTNXJkXJJkuynDPz0x7fKjDf3L) **(\*)**
 
 &nbsp;
 
@@ -361,7 +361,7 @@ TAB 1
 
 ### Automation and control in electric and hybrid vehicles
 
-*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/12r6ir-L7ZYedaiKsd21QZ8aJkXAbbFD8)
+*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/12r6ir-L7ZYedaiKsd21QZ8aJkXAbbFD8) **(\*)**
 
 ### Numerical Methods in Microelectronics
 
@@ -370,7 +370,7 @@ TAB 1
 ### Design of Hardware Accelerators
 
 *   Course notes by _Guido Rolle_ - [Notes](TAB1/HardwareAccelerators/HardwareAccelerators.pdf) - [Markdown source](TAB1/HardwareAccelerators/HWACC.md)
-*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1NLIfOZ-jwgkg6_cyv0STUiMOF6GvWFJT)
+*   Course notes by _Mattia Amadori_ - [Folder](https://drive.google.com/drive/folders/1NLIfOZ-jwgkg6_cyv0STUiMOF6GvWFJT) **(\*)**
 
 ### Optical Measurements
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -94,13 +94,13 @@ Primo anno
 
 ### Chimica
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/Q4hy2Rgb#7iPOP8n_X9mUllrrs1OyyQ)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/Q4hy2Rgb#7iPOP8n_X9mUllrrs1OyyQ) **(\*)**
 *   Tabella riassuntiva [Orto-Meta-Para orientanti](1/Chimica/OMPBenzene.pdf)
 *   Appunti di _Pietro Giannoccaro_ - [Download](1/Chimica/appuntiGiannoccaro.pdf)
 
 ### Informatica
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/doJQxRTK#oP3vuq2p9OQ-wjHXcwDu6Q)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/doJQxRTK#oP3vuq2p9OQ-wjHXcwDu6Q) **(\*)**
 *   [Appunti generali](1/Informatica/noteVelociFDInformatica.pdf)
 *   [Appunti stdio](1/Informatica/stdio.pdf)
 *   [Appunti stdlib](1/Informatica/stdlib.pdf)
@@ -113,12 +113,12 @@ Primo anno
 
 ### Fisica 1
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/QxRm0JCZ#B05MLcw3tU8x4eFMoLGwUA)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/QxRm0JCZ#B05MLcw3tU8x4eFMoLGwUA) **(\*)**
 *   Formulario di [_Giuseppe Chierchia_](https://sites.google.com/view/giuseppechierchia/materiale-tecnico) - [Mirror](1/Fisica1/FormularioFIS1chierchia.pdf) **(\*)**
 
 ### Economia
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/opRGzb4C#6ezLCsyGkJBtRo7L1u8oKQ)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/opRGzb4C#6ezLCsyGkJBtRo7L1u8oKQ) **(\*)**
 
 &nbsp;
 
@@ -129,33 +129,33 @@ Secondo anno
 
 ### Analisi 2
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/w5hgjDKD#Se9OADU_LmcbxUlFfTzs8Q)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/w5hgjDKD#Se9OADU_LmcbxUlFfTzs8Q) **(\*)**
 *   Formulario di [_Giuseppe Chierchia_](https://sites.google.com/view/giuseppechierchia/materiale-tecnico) - [Mirror](2/AM2/formularioAM2chierchia.pdf) **(\*)**
 *   [Domande tipiche degli orali](http://www1.mate.polimi.it/~bramanti/corsi/temidesame_analisi2/domande_orali_2019.pdf) - [Mirror](2/AM2/domande_orali_2019.pdf)
 
 ### Elettromagnetismo ed ottica
 
 *   Concetti riassuntivi della teoria del Prof. Laporta - [Download](2/EEO/EEO_ConcettiRiassuntivi_UnicoStampa.pdf)
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/Ah5g1DTQ#jtuBwLooK_87YXFkgsYAUw)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/Ah5g1DTQ#jtuBwLooK_87YXFkgsYAUw) **(\*)**
 *   Rifrazione e riflessione dal principio di fermat [da batmath.it](http://www.batmath.it/fisica/fondamenti/rifl_rifr/rifl_rifr.htm) **(\*)**
 *   Formulario di [_Giuseppe Chierchia_](https://sites.google.com/view/giuseppechierchia/materiale-tecnico) - [Mirror](2/EEO/formularioEEOchierchia.pdf) **(\*)**
 *   Domande di teoria degli esami - [Link](https://github.com/valerionew/triennale-elettronica-polimi/blob/master/static/2/EEO/domandeTeoria.md)
 
 ### Elettrotecnica
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/Ex42mByZ#wD6G5eFB01aDDTVMqzuKXg)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/Ex42mByZ#wD6G5eFB01aDDTVMqzuKXg) **(\*)**
 *   Raccolta di temi d'esame a cura di _Dino Ghilardi_ (_CC BY-NC-SA 3.0_) - [Link](https://damore.faculty.polimi.it/download/temiDEsame.pdf) - [Mirror](2/Elettrotecnica/temiDEsame.pdf)
 *   Compendio/formulario di _Pietro Giannoccaro_ - [Download](2/Elettrotecnica/formularioGiannoccaro.pdf)
 
 ### Fondamenti di automatica
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/ZsAAVRgK#zqkxEcOdi1VYIzRtDY2rkw)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/ZsAAVRgK#zqkxEcOdi1VYIzRtDY2rkw) **(\*)**
 *   Risposte ad alcune tipiche domande di teoria - [Download](2/FDA/teoria_automatica.pdf)
 *   Appunti di _Giacomo Tombolan_ del corso - Download: [Parte 1](2/FDA/appuntiTombolan/1_TOMBOLAN_AUTOMATICA_CORNO_2018.pdf) - [Parte 2](2/FDA/appuntiTombolan/33_TOMBOLAN_AUTOMATICA_CORNO_2018.pdf) - [Parte 3](2/FDA/appuntiTombolan/61_TOMBOLAN_AUTOMATICA_CORNO_2018.pdf)
 
 ### Dispositivi elettronici
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/VhJgVDKA#nQkA2sXq8NXwOcMD0L2LZw)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/VhJgVDKA#nQkA2sXq8NXwOcMD0L2LZw) **(\*)**
 *   Risposte alle domande per la discussione orale - [Download](2/DE/DomandeOrale.pdf)
 *   Collezione di esercizi svolti (alcuni sbagliati o incompleti, la maggior parte giusti) - [Download](2/DE/HomeworkS.zip)
 *   Formulario di _Alessio Serraino_ - [Download](2/DE/formularioSerraino.pdf)
@@ -163,13 +163,13 @@ Secondo anno
 
 ### Architetture dei calcolatori
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/MhhWHT4D#9UOTcMcP_jEpYdLmhsp6bQ)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/MhhWHT4D#9UOTcMcP_jEpYdLmhsp6bQ) **(\*)**
 *   Appunti di _Pietro Giannoccaro_ - [Download](2/ArchCalc/ArchitettureDeiCalcolatori-PietroGiannoccaro.pdf)
 *   Brevi appunti manoscritti - [Download](2/ArchCalc/appuntiArchCalc.pdf)
 
 ### Fondamenti di elettronica
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/hogSVToa#CCYWLTbUAuxWRKTE5MxOVg)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/hogSVToa#CCYWLTbUAuxWRKTE5MxOVg) **(\*)**
 *   Appunti di lezioni ed esercitazioni di _Francesco Bossio_ - [Cartella](https://github.com/valerionew/triennale-elettronica-polimi/tree/master/static/2/FDE/appuntiBossio)
 *   Appunti di _Giacomo Tombolan_ del corso - Download [Parte 1](2/FDE/appuntiTombolan/1_TOMBOLAN_FDE_2018_APPUNTI.pdf) - [Parte 2](2/FDE/appuntiTombolan/22_TOMBOLAN_FDE_2018_APPUNTI.pdf) - [Parte 3](2/FDE/appuntiTombolan/38_TOMBOLAN_FDE_2018_APPUNTI.pdf) - [Parte 4](2/FDE/appuntiTombolan/53_TOMBOLAN_FDE_2018_APPUNTI.pdf) - [Parte 5](2/FDE/appuntiTombolan/73_TOMBOLAN_FDE_2018_APPUNTI.pdf)
 *   [Alcune domande degli esami orali](https://github.com/valerionew/triennale-elettronica-polimi/blob/master/static/2/FDE/domandeElettronica.md)
@@ -183,7 +183,7 @@ Terzo anno
 
 ### Elettronica digitale
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/04AkkJia#p4sURbtF3DmMk96W6KEP3w)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/04AkkJia#p4sURbtF3DmMk96W6KEP3w) **(\*)**
 *   VHDL Cheatsheet di _Lorenzo Rossi_ - [Download](3/Digitale/vhdl.pdf)
 \- [Repository](https://github.com/lorossi/appunti-vhdl)
 *   Appunti rapidi di elettronica digitale di _Lorenzo Rossi_ - [Download](3/Digitale/appunti_digitale.pdf) - [Sorgenti LaTeX](https://github.com/valerionew/triennale-elettronica-polimi/blob/master/static/3/Digitale/appunti_digitale.tex)
@@ -196,7 +196,7 @@ Terzo anno
 
 ### Fondamenti di segnali
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/Y9xmnBbY#IE30YBzg-g3L6GIx4464mA)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/Y9xmnBbY#IE30YBzg-g3L6GIx4464mA) **(\*)**
 *   Appunti di _Andrea Bertazzoni_ - [Probabilità](3/Segnali/probabilitaBertazzoni.pdf) - [Segnali](3/Segnali/segnaliBertazzoni.pdf) - [Trasmissioni](3/Segnali/trasmissioniBertazzoni.pdf) - [Processi](3/Segnali/processiBertazzoni.pdf) (non completo)
 *   Dispense ed Esercizi svolti _proff. Barni e De Rosa_ - [Link diretto](https://www3.diism.unisi.it/~pozzebon/comunicazioni_elettriche/segnali/dispense/dispense_tds.pdf) - [Mirror](3/Segnali/dispense_tds.pdf)
 *   Formulario di _Lorenzo Rossi_ - [Download](3/Segnali/20191128_1130_FORMULARIO.pdf)
@@ -205,7 +205,7 @@ Terzo anno
 
 ### Calcolo numerico
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/ZkpiGY6L#PmtUCNVhu_5XDsVj5rogBg)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/ZkpiGY6L#PmtUCNVhu_5XDsVj5rogBg) **(\*)**
 *   Laboratori: [https://github.com/valerionew/calcolo\_numerico](https://github.com/valerionew/calcolo_numerico)
 
 ### Microcontrollori
@@ -217,7 +217,7 @@ Terzo anno
 
 ### Campi elettromagnetici
 
-*   Appunti di _Lorenzo Perlo_ e _Alessandro Perna_ - [Cartella](https://mega.nz/folder/YkhClASa#x_uoPjlGKTnmuX-r_IevgA)
+*   Appunti di _Lorenzo Perlo_ e _Alessandro Perna_ - [Cartella](https://mega.nz/folder/YkhClASa#x_uoPjlGKTnmuX-r_IevgA) **(\*)**
 *   Formulario di _Lorenzo Rossi_ - [Repository](https://github.com/lorossi/formulario-campi-elettromagnetici) - [Link diretto](https://github.com/lorossi/formulario-campi-elettromagnetici/raw/master/formulario_campi.pdf) - [Mirror](3/CEM/formulario_campi.pdf)
 *   Appunti di _Andrea Bertazzoni_ - [Download](3/CEM/campiBertazzoni.pdf)
 *   Temi d'esame risolti di _Andreja Marinkovic_ - [Download](3/CEM/campiTemiDEsameMarinkovic.pdf)
@@ -229,7 +229,7 @@ Terzo anno
 
 ### Elettronica dello stato solido
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/UkBFHYjL#lOHzgWuYxroO8qPBM8DYJA)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/UkBFHYjL#lOHzgWuYxroO8qPBM8DYJA) **(\*)**
 *   Appunti incompleti sui casi risolutivi dell'equazione di Schrödinger - [Download](3/ESS/schrodinger.pdf) - [Sorgenti LaTeX](3/ESS/schrodinger.tex)
 *   Formulario di _Lorenzo Rossi_ - [Repository](https://github.com/lorossi/formulario-stato-solido) - [Link diretto](https://github.com/lorossi/formulario-stato-solido/raw/master/formulario-elettronica-dello-stato-solido.pdf) - [Mirror](3/ESS/formulario-elettronica-dello-stato-solido.pdf)
 *   Appunti di _Mattia Marinoni_ - [Download](3/ESS/appuntiMarinoni.pdf)
@@ -237,7 +237,7 @@ Terzo anno
 
 ### Optoelettronica
 
-*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/4so2WSLT#mz8ZNMKP3FTHZ4VB7UFIhg)
+*   Appunti di _Lorenzo Perlo_ - [Cartella](https://mega.nz/folder/4so2WSLT#mz8ZNMKP3FTHZ4VB7UFIhg) **(\*)**
 *   Formulario di _Lorenzo Rossi_ e raccolta di domande di teoria - [Download](https://github.com/lorossi/formulario-optoelettronica/raw/master/formulario-optoelettronica.pdf) - [Mirror](3/Optoelettronica/formularioRossiOpto.pdf) - [Repository](https://github.com/lorossi/formulario-optoelettronica)
 *   Appunti di _Andrea Al Muktash_ - [Download](3/Optoelettronica/optoelettronicaAlMuktash.pdf)
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -419,10 +419,12 @@ TAB 2
 Extra
 =====
 
-🇮🇹 &nbsp;Gli appunti sono nella stessa lingua in cui viene erogato il corso.  
+🇮🇹 &nbsp; **(\*)**  è spiegato [qui]({{< ref "licenses.md#external-links" >}}).  
+Gli appunti sono nella stessa lingua in cui viene erogato il corso.  
 ***Buono studio 💪***
 
-🇬🇧 &nbsp;The notes are in the same language in which the course is delivered.  
+🇬🇧 &nbsp; **(\*)** explained [here]({{< ref "licenses.md#external-links" >}}).  
+The notes are in the same language in which the course is delivered.  
 ***Good study 🤓***
 
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -420,9 +420,11 @@ Extra
 =====
 
 🇮🇹 &nbsp;Gli appunti sono nella stessa lingua in cui viene erogato il corso.  
+👉 **(\*)** indica una risorsa esterna (sia al sito che alla repo Github).  
 ***Buono studio 💪***
 
 🇬🇧 &nbsp;The notes are in the same language in which the course is delivered.  
+👉 **(\*)** indicates an external resource (not hosted on the website or on the GitHub repository).  
 ***Good study 🤓***
 
 

--- a/content/contact.md
+++ b/content/contact.md
@@ -9,11 +9,11 @@ weight = -2
 ## Support
 
 🇮🇹 &nbsp;**Condividi eventuali problemi col sito o tue idee**.  
-Puoi farlo via email qui sotto o via [Github](https://github.com/valerionew/triennale-elettronica-polimi/issues/new).  
+Puoi farlo via email qui sotto o via [Github](https://github.com/valerionew/triennale-elettronica-polimi/issues/new). {{< alternative_it >}}  
 _Qui sotto puoi anche mandare direttamente i tuoi appunti_.
 
 🇬🇧 &nbsp;**Feel free to share any issues with the website or your ideas**.  
-You can do it down below or open an issue on [Github](https://github.com/valerionew/triennale-elettronica-polimi/issues/new).  
+You can do it down below or open an issue on [Github](https://github.com/valerionew/triennale-elettronica-polimi/issues/new). {{< alternative_en >}}  
 _Down below you can also send your notes directly_.
 
 * * *

--- a/content/licenses.md
+++ b/content/licenses.md
@@ -16,6 +16,8 @@ In general, except otherwise specified, the author's material and the other righ
 
 * * *
 
+### External links
+
 🇮🇹 &nbsp;**(\*)**: indica il materiale liberamente disponibile in rete riportato su questa risorsa. Dove lo si è ritenuto opportuno, si è provveduto a creare una copia locale, nel caso le risorse diventassero non più disponibili in futuro. **Tutti i diritti restano dei rispettivi autori.**  
 
 🇬🇧 &nbsp;**(\*)**: marks the material freely available on internet, reported in this resource. Where it was deemed appropriate, we proceeded to create a local mirror, in case the resource stops beeing available in the future. **All the rights remain to the respective authors.**

--- a/content/report-a-copyright-violation.md
+++ b/content/report-a-copyright-violation.md
@@ -8,7 +8,7 @@ weight = -1
 
 ## 🇬🇧 &nbsp;Report a copyright violation
 
-[![Copyright violation](https://img.shields.io/badge/copyright-violation-red?style=flat)](https://github.com/valerionew/triennale-elettronica-polimi/issues/new?assignees=&labels=Copyright&template=report-violazione-di-copyright.md)
+[{{< copyright >}}](https://github.com/valerionew/triennale-elettronica-polimi/issues/new?assignees=&labels=Copyright&template=report-violazione-di-copyright.md)
 
 You have two options for reporting copyright violations:
 

--- a/layouts/shortcodes/alternative_en.html
+++ b/layouts/shortcodes/alternative_en.html
@@ -1,0 +1,1 @@
+<span id="alternative-en"></span>

--- a/layouts/shortcodes/alternative_it.html
+++ b/layouts/shortcodes/alternative_it.html
@@ -1,0 +1,1 @@
+<span id="alternative-it"></span>

--- a/layouts/shortcodes/contact.html
+++ b/layouts/shortcodes/contact.html
@@ -105,6 +105,18 @@
       });
     }
 
+    var host = window.location.host;
+    var span_it = document.getElementById("alternative-it");
+    var span_en = document.getElementById("alternative-en");
+
+    if (host.includes("netlify")) {
+      span_it.innerHTML = `Se incontri dei problemi con l'attuale sito prova sulla <a href="https://valerionew.github.io/triennale-elettronica-polimi/">Github Page</a>.`;
+      span_en.innerHTML = `If you encounter any problem with the actual website you can try the <a href="https://valerionew.github.io/triennale-elettronica-polimi/">Github Page</a>.`;
+    } else if (host.includes("github")) {
+      span_it.innerHTML = `Se incontri dei problemi con l'attuale sito prova sul <a href="https://triennale-elettronica-polimi.netlify.app/">Netlify Mirror</a>.`;
+      span_en.innerHTML = `If you encounter any problem with the actual website you can try the <a href="https://triennale-elettronica-polimi.netlify.app/">Netlify Mirror</a>.`;
+    }
+
     form.addEventListener("submit", handleSubmit);
 
   })

--- a/layouts/shortcodes/contact.html
+++ b/layouts/shortcodes/contact.html
@@ -111,10 +111,10 @@
 
     if (host.includes("netlify")) {
       span_it.innerHTML = `Se incontri dei problemi con l'attuale sito prova sulla <a href="https://valerionew.github.io/triennale-elettronica-polimi/">Github Page</a>.`;
-      span_en.innerHTML = `If you encounter any problem with the actual website you can try the <a href="https://valerionew.github.io/triennale-elettronica-polimi/">Github Page</a>.`;
+      span_en.innerHTML = `If you encounter any problem with the current website you can try the <a href="https://valerionew.github.io/triennale-elettronica-polimi/">Github Page</a>.`;
     } else if (host.includes("github")) {
       span_it.innerHTML = `Se incontri dei problemi con l'attuale sito prova sul <a href="https://triennale-elettronica-polimi.netlify.app/">Netlify Mirror</a>.`;
-      span_en.innerHTML = `If you encounter any problem with the actual website you can try the <a href="https://triennale-elettronica-polimi.netlify.app/">Netlify Mirror</a>.`;
+      span_en.innerHTML = `If you encounter any problem with the current website you can try the <a href="https://triennale-elettronica-polimi.netlify.app/">Netlify Mirror</a>.`;
     }
 
     form.addEventListener("submit", handleSubmit);

--- a/layouts/shortcodes/copyright.html
+++ b/layouts/shortcodes/copyright.html
@@ -1,0 +1,58 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  width="118"
+  height="20"
+  role="img"
+  aria-label="copyright: violation"
+>
+  <title>copyright: violation</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+    <stop offset="1" stop-opacity=".1" />
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="118" height="20" rx="3" fill="#fff" />
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="61" height="20" fill="#555" />
+    <rect x="61" width="57" height="20" fill="#e05d44" />
+    <rect width="118" height="20" fill="url(#s)" />
+  </g>
+  <g
+    fill="#fff"
+    text-anchor="middle"
+    font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+    text-rendering="geometricPrecision"
+    font-size="110"
+  >
+    <text
+      aria-hidden="true"
+      x="315"
+      y="150"
+      fill="#010101"
+      fill-opacity=".3"
+      transform="scale(.1)"
+      textLength="510"
+    >
+      copyright
+    </text>
+    <text x="315" y="140" transform="scale(.1)" fill="#fff" textLength="510">
+      copyright
+    </text>
+    <text
+      aria-hidden="true"
+      x="885"
+      y="150"
+      fill="#010101"
+      fill-opacity=".3"
+      transform="scale(.1)"
+      textLength="470"
+    >
+      violation
+    </text>
+    <text x="885" y="140" transform="scale(.1)" fill="#fff" textLength="470">
+      violation
+    </text>
+  </g>
+</svg>

--- a/public/contact/index.html
+++ b/public/contact/index.html
@@ -10,22 +10,18 @@
 <title>Support | Electronics engineering at Polimi 📝</title>
 <meta name="title" content="Support" />
 <meta name="description" content="Support 🇮🇹 Condividi eventuali problemi col sito o tue idee.
-Puoi farlo via email qui sotto o via Github.
-Qui sotto puoi anche mandare direttamente i tuoi appunti.
+Puoi farlo via email qui sotto o via Github. Qui sotto puoi anche mandare direttamente i tuoi appunti.
 🇬🇧 Feel free to share any issues with the website or your ideas.
-You can do it down below or open an issue on Github.
-Down below you can also send your notes directly.
+You can do it down below or open an issue on Github. Down below you can also send your notes directly.
 E-mail us Name&nbsp;E-mail address&nbsp;Message&nbsp;SubmitYou need Javascript for CAPTCHA verification to submit this form." />
 <meta name="keywords" content="" />
 
 
 <meta property="og:title" content="Support" />
 <meta property="og:description" content="Support 🇮🇹 Condividi eventuali problemi col sito o tue idee.
-Puoi farlo via email qui sotto o via Github.
-Qui sotto puoi anche mandare direttamente i tuoi appunti.
+Puoi farlo via email qui sotto o via Github. Qui sotto puoi anche mandare direttamente i tuoi appunti.
 🇬🇧 Feel free to share any issues with the website or your ideas.
-You can do it down below or open an issue on Github.
-Down below you can also send your notes directly.
+You can do it down below or open an issue on Github. Down below you can also send your notes directly.
 E-mail us Name&nbsp;E-mail address&nbsp;Message&nbsp;SubmitYou need Javascript for CAPTCHA verification to submit this form." />
 <meta property="og:type" content="article" />
 <meta property="og:url" content="/contact/" /><meta property="article:section" content="" />
@@ -37,22 +33,18 @@ E-mail us Name&nbsp;E-mail address&nbsp;Message&nbsp;SubmitYou need Javas
 <meta name="twitter:card" content="summary"/>
 <meta name="twitter:title" content="Support"/>
 <meta name="twitter:description" content="Support 🇮🇹 Condividi eventuali problemi col sito o tue idee.
-Puoi farlo via email qui sotto o via Github.
-Qui sotto puoi anche mandare direttamente i tuoi appunti.
+Puoi farlo via email qui sotto o via Github. Qui sotto puoi anche mandare direttamente i tuoi appunti.
 🇬🇧 Feel free to share any issues with the website or your ideas.
-You can do it down below or open an issue on Github.
-Down below you can also send your notes directly.
+You can do it down below or open an issue on Github. Down below you can also send your notes directly.
 E-mail us Name&nbsp;E-mail address&nbsp;Message&nbsp;SubmitYou need Javascript for CAPTCHA verification to submit this form."/>
 
 
 
 <meta itemprop="name" content="Support">
 <meta itemprop="description" content="Support 🇮🇹 Condividi eventuali problemi col sito o tue idee.
-Puoi farlo via email qui sotto o via Github.
-Qui sotto puoi anche mandare direttamente i tuoi appunti.
+Puoi farlo via email qui sotto o via Github. Qui sotto puoi anche mandare direttamente i tuoi appunti.
 🇬🇧 Feel free to share any issues with the website or your ideas.
-You can do it down below or open an issue on Github.
-Down below you can also send your notes directly.
+You can do it down below or open an issue on Github. Down below you can also send your notes directly.
 E-mail us Name&nbsp;E-mail address&nbsp;Message&nbsp;SubmitYou need Javascript for CAPTCHA verification to submit this form.">
 
 <meta itemprop="wordCount" content="101">
@@ -123,10 +115,12 @@ E-mail us Name&nbsp;E-mail address&nbsp;Message&nbsp;SubmitYou need Javas
   <hr>
 <h2 id="support">Support</h2>
 <p>🇮🇹  <strong>Condividi eventuali problemi col sito o tue idee</strong>.<br>
-Puoi farlo via email qui sotto o via <a href="https://github.com/valerionew/triennale-elettronica-polimi/issues/new">Github</a>.<br>
+Puoi farlo via email qui sotto o via <a href="https://github.com/valerionew/triennale-elettronica-polimi/issues/new">Github</a>. <span id="alternative-it"></span>
+<br>
 <em>Qui sotto puoi anche mandare direttamente i tuoi appunti</em>.</p>
 <p>🇬🇧  <strong>Feel free to share any issues with the website or your ideas</strong>.<br>
-You can do it down below or open an issue on <a href="https://github.com/valerionew/triennale-elettronica-polimi/issues/new">Github</a>.<br>
+You can do it down below or open an issue on <a href="https://github.com/valerionew/triennale-elettronica-polimi/issues/new">Github</a>. <span id="alternative-en"></span>
+<br>
 <em>Down below you can also send your notes directly</em>.</p>
 <hr>
 <h3 id="e-mail-us">E-mail us</h3>
@@ -235,6 +229,18 @@ You can do it down below or open an issue on <a href="https://github.com/valerio
         status.style.color = '#d00';
 
       });
+    }
+
+    var host = window.location.host;
+    var span_it = document.getElementById("alternative-it");
+    var span_en = document.getElementById("alternative-en");
+
+    if (host.includes("netlify")) {
+      span_it.innerHTML = `Se incontri dei problemi con l'attuale sito prova sulla <a href="https://valerionew.github.io/triennale-elettronica-polimi/">Github Page</a>.`;
+      span_en.innerHTML = `If you encounter any problem with the actual website you can try the <a href="https://valerionew.github.io/triennale-elettronica-polimi/">Github Page</a>.`;
+    } else if (host.includes("github")) {
+      span_it.innerHTML = `Se incontri dei problemi con l'attuale sito prova sul <a href="https://triennale-elettronica-polimi.netlify.app/">Netlify Mirror</a>.`;
+      span_en.innerHTML = `If you encounter any problem with the actual website you can try the <a href="https://triennale-elettronica-polimi.netlify.app/">Netlify Mirror</a>.`;
     }
 
     form.addEventListener("submit", handleSubmit);

--- a/public/index.html
+++ b/public/index.html
@@ -506,9 +506,11 @@ Notes from students on electronics engineering at Politecnico di Milano">
 <hr>
 <p> </p>
 <h1 id="extra">Extra</h1>
-<p>🇮🇹  Gli appunti sono nella stessa lingua in cui viene erogato il corso.<br>
+<p>🇮🇹   <strong>(*)</strong>  è spiegato <a href="/licenses/#external-links">qui</a>.<br>
+Gli appunti sono nella stessa lingua in cui viene erogato il corso.<br>
 <em><strong>Buono studio 💪</strong></em></p>
-<p>🇬🇧  The notes are in the same language in which the course is delivered.<br>
+<p>🇬🇧   <strong>(*)</strong> explained <a href="/licenses/#external-links">here</a>.<br>
+The notes are in the same language in which the course is delivered.<br>
 <em><strong>Good study 🤓</strong></em></p>
 <p> </p>
 <hr>

--- a/public/index.html
+++ b/public/index.html
@@ -507,10 +507,8 @@ Notes from students on electronics engineering at Politecnico di Milano">
 <p> </p>
 <h1 id="extra">Extra</h1>
 <p>🇮🇹  Gli appunti sono nella stessa lingua in cui viene erogato il corso.<br>
-👉 <strong>(*)</strong> indica una risorsa esterna (sia al sito che alla repo Github).<br>
 <em><strong>Buono studio 💪</strong></em></p>
 <p>🇬🇧  The notes are in the same language in which the course is delivered.<br>
-👉 <strong>(*)</strong> indicates an external resource (not hosted on the website or on the GitHub repository).<br>
 <em><strong>Good study 🤓</strong></em></p>
 <p> </p>
 <hr>

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-	<meta name="generator" content="Hugo 0.118.2">
+	<meta name="generator" content="Hugo 0.119.0">
   <meta http-equiv="X-Clacks-Overhead" content="GNU Terry Pratchett" />
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -381,12 +381,13 @@ Notes from students on electronics engineering at Politecnico di Milano">
 <ul>
 <li>Course notes by <em>Andrea Bertazzoni</em> - <a href="4/Analog/AnalogCircuitDesign-Bertazzoni.pdf">Download</a></li>
 <li>Summaries for the oral exam by <em>Leonardo Sera</em> (<em>questions 1-32</em>) - <a href="4/Analog/ACD_Summaries_Sera.pdf">Download</a></li>
-<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1EHAdoGCdYNnAqupD2ju8tO2S0vs1d0OL">Folder</a></li>
+<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1EHAdoGCdYNnAqupD2ju8tO2S0vs1d0OL">Folder</a> <strong>(*)</strong></li>
+<li>Oral questions complete notes by <em>Giacomo Tombolan</em> - <a href="4/Analog/AnalogCircuitDesign_TOMBOLAN.pdf">Download</a></li>
 </ul>
 <h3 id="mems-and-microsensors">MEMS and Microsensors</h3>
 <ul>
 <li>Course notes written in Latex by <em>Francesco Lenzi &amp; Donato Carlo Giorgio</em> - <a href="4/MEMS/MEMS_and_Microsensors.pdf">Download</a></li>
-<li>Course notes and formulary by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1rBTR7KC1rNfscHHJlDm7ZIyfFny1-2YM">Folder</a></li>
+<li>Course notes and formulary by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1rBTR7KC1rNfscHHJlDm7ZIyfFny1-2YM">Folder</a> <strong>(*)</strong></li>
 </ul>
 <h3 id="electron-devices">Electron Devices</h3>
 <ul>
@@ -396,19 +397,20 @@ Notes from students on electronics engineering at Politecnico di Milano">
 <ul>
 <li>Course notes by <em>Francesco Forestieri</em> - <a href="4/ElectronicSystems/ES_Theory_Forestieri.zip">Theory</a> - <a href="4/ElectronicSystems/ES_Exercises_Forestieri.zip">Exercises</a></li>
 <li>Course notes by <em>Luca Colombo</em> - <a href="4/ElectronicSystems/ElectronicSystems.pdf">Download</a></li>
-<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1RIdzefSzCJRy1k41KNpi7umDvHbOc3Cc">Folder</a></li>
+<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1RIdzefSzCJRy1k41KNpi7umDvHbOc3Cc">Folder</a> <strong>(*)</strong></li>
 </ul>
 <h3 id="signal-recovery">Signal Recovery</h3>
 <ul>
 <li>Solutions of the tutorials by <em>Simone Guglielmino</em> - <a href="https://github.com/valerionew/triennale-elettronica-polimi/tree/master/static/4/SignalRecovery/TutorialsTranscripts">Folder</a> - <a href="4/SignalRecovery/TutorialsTranscripts/SRTranscripts.zip">Download</a></li>
 <li>Course notes by <em>Luca Colombo</em> - <a href="4/SignalRecovery/SignalRecovery.pdf">Download</a></li>
 <li>Cheat sheet by <em>Giacomo Tombolan</em> - <a href="4/SignalRecovery/TOMBOLAN_SR_CHEAT_SHEET.pdf">Download</a></li>
-<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1oWAigQAJpLHzZl8WDYJxM7WvihO_sY8T">Folder</a></li>
+<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1oWAigQAJpLHzZl8WDYJxM7WvihO_sY8T">Folder</a> <strong>(*)</strong></li>
 </ul>
 <h3 id="rf-circuit-design">RF Circuit Design</h3>
 <ul>
 <li>Course notes by <em>Andrea Bertazzoni</em> - <a href="4/RFCircuitDesign/RFCircuitDesign-Bertazzoni.pdf">Download</a></li>
-<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/15yBgF_jmEApOPBcul8NRNnyfJOv_r8J0">Folder</a></li>
+<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/15yBgF_jmEApOPBcul8NRNnyfJOv_r8J0">Folder</a> <strong>(*)</strong></li>
+<li>Oral questions complete notes by <em>Giacomo Tombolan</em> - <a href="4/RFCircuitDesign/RadioFrequencyCircuitDesign_TOMBOLAN.pdf">Download</a></li>
 </ul>
 <h3 id="digital-integrated-circuit-design">Digital Integrated Circuit Design</h3>
 <ul>
@@ -421,15 +423,16 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="biochip">Biochip</h3>
 <ul>
-<li>Course notes on <a href="https://www.studwiz.com/notes/polimi/engineering/06-biomedical-engineering/subject-163/index.php">Stduwiz</a> (add them to Prof&rsquo;s slides)</li>
-<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/18qR8uuJGY1ekr2HxXgdR9YouXcNjTZnu">Folder</a></li>
+<li>Course notes on <a href="https://www.studwiz.com/notes/polimi/engineering/06-biomedical-engineering/subject-163/index.php">Stduwiz</a> (add them to Prof&rsquo;s slides) <strong>(*)</strong></li>
+<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/18qR8uuJGY1ekr2HxXgdR9YouXcNjTZnu">Folder</a> <strong>(*)</strong></li>
 </ul>
 <p> </p>
 <hr>
 <h2 id="second-year">Second year</h2>
 <h3 id="mixed-signal-circuit-design">Mixed-Signal Circuit Design</h3>
 <ul>
-<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1Dt6Us1RiZQkEG-8oJ6TgEohX7T3i1Dvi">Folder</a></li>
+<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1Dt6Us1RiZQkEG-8oJ6TgEohX7T3i1Dvi">Folder</a> <strong>(*)</strong></li>
+<li>Oral questions complete notes by <em>Giacomo Tombolan</em> - <a href="5/MixedSignal/MixedSignalCircuitDesign_TOMBOLAN.pdf">Download</a></li>
 </ul>
 <h3 id="power-electronics">Power Electronics</h3>
 <ul>
@@ -437,13 +440,13 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="microelectronic-technologies">Microelectronic Technologies</h3>
 <ul>
-<li>Course notes by <em>Mikel Kumria</em> - <a href="https://drive.google.com/drive/folders/12AprM4BqPXh8qebSwoPI3FGgb9QD1zvW">Folder</a></li>
+<li>Course notes by <em>Mikel Kumria</em> - <a href="https://drive.google.com/drive/folders/12AprM4BqPXh8qebSwoPI3FGgb9QD1zvW">Folder</a> <strong>(*)</strong></li>
 </ul>
 <h3 id="electronic-design-for-biomedical-instrumentation">Electronic Design For Biomedical Instrumentation</h3>
 <ul>
 <li>Course notes by <em>Luca Colombo</em> - <a href="5/EDFBI/ElectronicsDesign.pdf">Download</a></li>
 <li>Summary by <em>Matteo Toia</em> - <a href="5/EDFBI/Summary_Toia.pdf">Download</a></li>
-<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1N2Xk5plTNXJkXJJkuynDPz0x7fKjDf3L">Folder</a></li>
+<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1N2Xk5plTNXJkXJJkuynDPz0x7fKjDf3L">Folder</a> <strong>(*)</strong></li>
 </ul>
 <p> </p>
 <hr>
@@ -454,7 +457,7 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="automation-and-control-in-electric-and-hybrid-vehicles">Automation and control in electric and hybrid vehicles</h3>
 <ul>
-<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/12r6ir-L7ZYedaiKsd21QZ8aJkXAbbFD8">Folder</a></li>
+<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/12r6ir-L7ZYedaiKsd21QZ8aJkXAbbFD8">Folder</a> <strong>(*)</strong></li>
 </ul>
 <h3 id="numerical-methods-in-microelectronics">Numerical Methods in Microelectronics</h3>
 <ul>
@@ -463,7 +466,7 @@ Notes from students on electronics engineering at Politecnico di Milano">
 <h3 id="design-of-hardware-accelerators">Design of Hardware Accelerators</h3>
 <ul>
 <li>Course notes by <em>Guido Rolle</em> - <a href="TAB1/HardwareAccelerators/HardwareAccelerators.pdf">Notes</a> - <a href="TAB1/HardwareAccelerators/HWACC.md">Markdown source</a></li>
-<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1NLIfOZ-jwgkg6_cyv0STUiMOF6GvWFJT">Folder</a></li>
+<li>Course notes by <em>Mattia Amadori</em> - <a href="https://drive.google.com/drive/folders/1NLIfOZ-jwgkg6_cyv0STUiMOF6GvWFJT">Folder</a> <strong>(*)</strong></li>
 </ul>
 <h3 id="optical-measurements">Optical Measurements</h3>
 <ul>

--- a/public/index.html
+++ b/public/index.html
@@ -215,13 +215,13 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="chimica">Chimica</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/Q4hy2Rgb#7iPOP8n_X9mUllrrs1OyyQ">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/Q4hy2Rgb#7iPOP8n_X9mUllrrs1OyyQ">Cartella</a> <strong>(*)</strong></li>
 <li>Tabella riassuntiva <a href="1/Chimica/OMPBenzene.pdf">Orto-Meta-Para orientanti</a></li>
 <li>Appunti di <em>Pietro Giannoccaro</em> - <a href="1/Chimica/appuntiGiannoccaro.pdf">Download</a></li>
 </ul>
 <h3 id="informatica">Informatica</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/doJQxRTK#oP3vuq2p9OQ-wjHXcwDu6Q">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/doJQxRTK#oP3vuq2p9OQ-wjHXcwDu6Q">Cartella</a> <strong>(*)</strong></li>
 <li><a href="1/Informatica/noteVelociFDInformatica.pdf">Appunti generali</a></li>
 <li><a href="1/Informatica/stdio.pdf">Appunti stdio</a></li>
 <li><a href="1/Informatica/stdlib.pdf">Appunti stdlib</a></li>
@@ -234,45 +234,45 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="fisica-1">Fisica 1</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/QxRm0JCZ#B05MLcw3tU8x4eFMoLGwUA">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/QxRm0JCZ#B05MLcw3tU8x4eFMoLGwUA">Cartella</a> <strong>(*)</strong></li>
 <li>Formulario di <a href="https://sites.google.com/view/giuseppechierchia/materiale-tecnico"><em>Giuseppe Chierchia</em></a> - <a href="1/Fisica1/FormularioFIS1chierchia.pdf">Mirror</a> <strong>(*)</strong></li>
 </ul>
 <h3 id="economia">Economia</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/opRGzb4C#6ezLCsyGkJBtRo7L1u8oKQ">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/opRGzb4C#6ezLCsyGkJBtRo7L1u8oKQ">Cartella</a> <strong>(*)</strong></li>
 </ul>
 <p> </p>
 <hr>
 <h2 id="secondo-anno">Secondo anno</h2>
 <h3 id="analisi-2">Analisi 2</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/w5hgjDKD#Se9OADU_LmcbxUlFfTzs8Q">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/w5hgjDKD#Se9OADU_LmcbxUlFfTzs8Q">Cartella</a> <strong>(*)</strong></li>
 <li>Formulario di <a href="https://sites.google.com/view/giuseppechierchia/materiale-tecnico"><em>Giuseppe Chierchia</em></a> - <a href="2/AM2/formularioAM2chierchia.pdf">Mirror</a> <strong>(*)</strong></li>
 <li><a href="http://www1.mate.polimi.it/~bramanti/corsi/temidesame_analisi2/domande_orali_2019.pdf">Domande tipiche degli orali</a> - <a href="2/AM2/domande_orali_2019.pdf">Mirror</a></li>
 </ul>
 <h3 id="elettromagnetismo-ed-ottica">Elettromagnetismo ed ottica</h3>
 <ul>
 <li>Concetti riassuntivi della teoria del Prof. Laporta - <a href="2/EEO/EEO_ConcettiRiassuntivi_UnicoStampa.pdf">Download</a></li>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/Ah5g1DTQ#jtuBwLooK_87YXFkgsYAUw">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/Ah5g1DTQ#jtuBwLooK_87YXFkgsYAUw">Cartella</a> <strong>(*)</strong></li>
 <li>Rifrazione e riflessione dal principio di fermat <a href="http://www.batmath.it/fisica/fondamenti/rifl_rifr/rifl_rifr.htm">da batmath.it</a> <strong>(*)</strong></li>
 <li>Formulario di <a href="https://sites.google.com/view/giuseppechierchia/materiale-tecnico"><em>Giuseppe Chierchia</em></a> - <a href="2/EEO/formularioEEOchierchia.pdf">Mirror</a> <strong>(*)</strong></li>
 <li>Domande di teoria degli esami - <a href="https://github.com/valerionew/triennale-elettronica-polimi/blob/master/static/2/EEO/domandeTeoria.md">Link</a></li>
 </ul>
 <h3 id="elettrotecnica">Elettrotecnica</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/Ex42mByZ#wD6G5eFB01aDDTVMqzuKXg">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/Ex42mByZ#wD6G5eFB01aDDTVMqzuKXg">Cartella</a> <strong>(*)</strong></li>
 <li>Raccolta di temi d&rsquo;esame a cura di <em>Dino Ghilardi</em> (<em>CC BY-NC-SA 3.0</em>) - <a href="https://damore.faculty.polimi.it/download/temiDEsame.pdf">Link</a> - <a href="2/Elettrotecnica/temiDEsame.pdf">Mirror</a></li>
 <li>Compendio/formulario di <em>Pietro Giannoccaro</em> - <a href="2/Elettrotecnica/formularioGiannoccaro.pdf">Download</a></li>
 </ul>
 <h3 id="fondamenti-di-automatica">Fondamenti di automatica</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/ZsAAVRgK#zqkxEcOdi1VYIzRtDY2rkw">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/ZsAAVRgK#zqkxEcOdi1VYIzRtDY2rkw">Cartella</a> <strong>(*)</strong></li>
 <li>Risposte ad alcune tipiche domande di teoria - <a href="2/FDA/teoria_automatica.pdf">Download</a></li>
 <li>Appunti di <em>Giacomo Tombolan</em> del corso - Download: <a href="2/FDA/appuntiTombolan/1_TOMBOLAN_AUTOMATICA_CORNO_2018.pdf">Parte 1</a> - <a href="2/FDA/appuntiTombolan/33_TOMBOLAN_AUTOMATICA_CORNO_2018.pdf">Parte 2</a> - <a href="2/FDA/appuntiTombolan/61_TOMBOLAN_AUTOMATICA_CORNO_2018.pdf">Parte 3</a></li>
 </ul>
 <h3 id="dispositivi-elettronici">Dispositivi elettronici</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/VhJgVDKA#nQkA2sXq8NXwOcMD0L2LZw">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/VhJgVDKA#nQkA2sXq8NXwOcMD0L2LZw">Cartella</a> <strong>(*)</strong></li>
 <li>Risposte alle domande per la discussione orale - <a href="2/DE/DomandeOrale.pdf">Download</a></li>
 <li>Collezione di esercizi svolti (alcuni sbagliati o incompleti, la maggior parte giusti) - <a href="2/DE/HomeworkS.zip">Download</a></li>
 <li>Formulario di <em>Alessio Serraino</em> - <a href="2/DE/formularioSerraino.pdf">Download</a></li>
@@ -280,13 +280,13 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="architetture-dei-calcolatori">Architetture dei calcolatori</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/MhhWHT4D#9UOTcMcP_jEpYdLmhsp6bQ">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/MhhWHT4D#9UOTcMcP_jEpYdLmhsp6bQ">Cartella</a> <strong>(*)</strong></li>
 <li>Appunti di <em>Pietro Giannoccaro</em> - <a href="2/ArchCalc/ArchitettureDeiCalcolatori-PietroGiannoccaro.pdf">Download</a></li>
 <li>Brevi appunti manoscritti - <a href="2/ArchCalc/appuntiArchCalc.pdf">Download</a></li>
 </ul>
 <h3 id="fondamenti-di-elettronica">Fondamenti di elettronica</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/hogSVToa#CCYWLTbUAuxWRKTE5MxOVg">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/hogSVToa#CCYWLTbUAuxWRKTE5MxOVg">Cartella</a> <strong>(*)</strong></li>
 <li>Appunti di lezioni ed esercitazioni di <em>Francesco Bossio</em> - <a href="https://github.com/valerionew/triennale-elettronica-polimi/tree/master/static/2/FDE/appuntiBossio">Cartella</a></li>
 <li>Appunti di <em>Giacomo Tombolan</em> del corso - Download <a href="2/FDE/appuntiTombolan/1_TOMBOLAN_FDE_2018_APPUNTI.pdf">Parte 1</a> - <a href="2/FDE/appuntiTombolan/22_TOMBOLAN_FDE_2018_APPUNTI.pdf">Parte 2</a> - <a href="2/FDE/appuntiTombolan/38_TOMBOLAN_FDE_2018_APPUNTI.pdf">Parte 3</a> - <a href="2/FDE/appuntiTombolan/53_TOMBOLAN_FDE_2018_APPUNTI.pdf">Parte 4</a> - <a href="2/FDE/appuntiTombolan/73_TOMBOLAN_FDE_2018_APPUNTI.pdf">Parte 5</a></li>
 <li><a href="https://github.com/valerionew/triennale-elettronica-polimi/blob/master/static/2/FDE/domandeElettronica.md">Alcune domande degli esami orali</a></li>
@@ -296,7 +296,7 @@ Notes from students on electronics engineering at Politecnico di Milano">
 <h2 id="terzo-anno">Terzo anno</h2>
 <h3 id="elettronica-digitale">Elettronica digitale</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/04AkkJia#p4sURbtF3DmMk96W6KEP3w">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/04AkkJia#p4sURbtF3DmMk96W6KEP3w">Cartella</a> <strong>(*)</strong></li>
 <li>VHDL Cheatsheet di <em>Lorenzo Rossi</em> - <a href="3/Digitale/vhdl.pdf">Download</a>
 - <a href="https://github.com/lorossi/appunti-vhdl">Repository</a></li>
 <li>Appunti rapidi di elettronica digitale di <em>Lorenzo Rossi</em> - <a href="3/Digitale/appunti_digitale.pdf">Download</a> - <a href="https://github.com/valerionew/triennale-elettronica-polimi/blob/master/static/3/Digitale/appunti_digitale.tex">Sorgenti LaTeX</a></li>
@@ -309,7 +309,7 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="fondamenti-di-segnali">Fondamenti di segnali</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/Y9xmnBbY#IE30YBzg-g3L6GIx4464mA">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/Y9xmnBbY#IE30YBzg-g3L6GIx4464mA">Cartella</a> <strong>(*)</strong></li>
 <li>Appunti di <em>Andrea Bertazzoni</em> - <a href="3/Segnali/probabilitaBertazzoni.pdf">Probabilità</a> - <a href="3/Segnali/segnaliBertazzoni.pdf">Segnali</a> - <a href="3/Segnali/trasmissioniBertazzoni.pdf">Trasmissioni</a> - <a href="3/Segnali/processiBertazzoni.pdf">Processi</a> (non completo)</li>
 <li>Dispense ed Esercizi svolti <em>proff. Barni e De Rosa</em> - <a href="https://www3.diism.unisi.it/~pozzebon/comunicazioni_elettriche/segnali/dispense/dispense_tds.pdf">Link diretto</a> - <a href="3/Segnali/dispense_tds.pdf">Mirror</a></li>
 <li>Formulario di <em>Lorenzo Rossi</em> - <a href="3/Segnali/20191128_1130_FORMULARIO.pdf">Download</a></li>
@@ -318,7 +318,7 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="calcolo-numerico">Calcolo numerico</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/ZkpiGY6L#PmtUCNVhu_5XDsVj5rogBg">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/ZkpiGY6L#PmtUCNVhu_5XDsVj5rogBg">Cartella</a> <strong>(*)</strong></li>
 <li>Laboratori: <a href="https://github.com/valerionew/calcolo_numerico">https://github.com/valerionew/calcolo_numerico</a></li>
 </ul>
 <h3 id="microcontrollori">Microcontrollori</h3>
@@ -330,7 +330,7 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="campi-elettromagnetici">Campi elettromagnetici</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> e <em>Alessandro Perna</em> - <a href="https://mega.nz/folder/YkhClASa#x_uoPjlGKTnmuX-r_IevgA">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> e <em>Alessandro Perna</em> - <a href="https://mega.nz/folder/YkhClASa#x_uoPjlGKTnmuX-r_IevgA">Cartella</a> <strong>(*)</strong></li>
 <li>Formulario di <em>Lorenzo Rossi</em> - <a href="https://github.com/lorossi/formulario-campi-elettromagnetici">Repository</a> - <a href="https://github.com/lorossi/formulario-campi-elettromagnetici/raw/master/formulario_campi.pdf">Link diretto</a> - <a href="3/CEM/formulario_campi.pdf">Mirror</a></li>
 <li>Appunti di <em>Andrea Bertazzoni</em> - <a href="3/CEM/campiBertazzoni.pdf">Download</a></li>
 <li>Temi d&rsquo;esame risolti di <em>Andreja Marinkovic</em> - <a href="3/CEM/campiTemiDEsameMarinkovic.pdf">Download</a></li>
@@ -342,7 +342,7 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="elettronica-dello-stato-solido">Elettronica dello stato solido</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/UkBFHYjL#lOHzgWuYxroO8qPBM8DYJA">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/UkBFHYjL#lOHzgWuYxroO8qPBM8DYJA">Cartella</a> <strong>(*)</strong></li>
 <li>Appunti incompleti sui casi risolutivi dell&rsquo;equazione di Schrödinger - <a href="3/ESS/schrodinger.pdf">Download</a> - <a href="3/ESS/schrodinger.tex">Sorgenti LaTeX</a></li>
 <li>Formulario di <em>Lorenzo Rossi</em> - <a href="https://github.com/lorossi/formulario-stato-solido">Repository</a> - <a href="https://github.com/lorossi/formulario-stato-solido/raw/master/formulario-elettronica-dello-stato-solido.pdf">Link diretto</a> - <a href="3/ESS/formulario-elettronica-dello-stato-solido.pdf">Mirror</a></li>
 <li>Appunti di <em>Mattia Marinoni</em> - <a href="3/ESS/appuntiMarinoni.pdf">Download</a></li>
@@ -350,7 +350,7 @@ Notes from students on electronics engineering at Politecnico di Milano">
 </ul>
 <h3 id="optoelettronica">Optoelettronica</h3>
 <ul>
-<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/4so2WSLT#mz8ZNMKP3FTHZ4VB7UFIhg">Cartella</a></li>
+<li>Appunti di <em>Lorenzo Perlo</em> - <a href="https://mega.nz/folder/4so2WSLT#mz8ZNMKP3FTHZ4VB7UFIhg">Cartella</a> <strong>(*)</strong></li>
 <li>Formulario di <em>Lorenzo Rossi</em> e raccolta di domande di teoria - <a href="https://github.com/lorossi/formulario-optoelettronica/raw/master/formulario-optoelettronica.pdf">Download</a> - <a href="3/Optoelettronica/formularioRossiOpto.pdf">Mirror</a> - <a href="https://github.com/lorossi/formulario-optoelettronica">Repository</a></li>
 <li>Appunti di <em>Andrea Al Muktash</em> - <a href="3/Optoelettronica/optoelettronicaAlMuktash.pdf">Download</a></li>
 </ul>

--- a/public/index.html
+++ b/public/index.html
@@ -507,8 +507,10 @@ Notes from students on electronics engineering at Politecnico di Milano">
 <p> </p>
 <h1 id="extra">Extra</h1>
 <p>🇮🇹  Gli appunti sono nella stessa lingua in cui viene erogato il corso.<br>
+👉 <strong>(*)</strong> indica una risorsa esterna (sia al sito che alla repo Github).<br>
 <em><strong>Buono studio 💪</strong></em></p>
 <p>🇬🇧  The notes are in the same language in which the course is delivered.<br>
+👉 <strong>(*)</strong> indicates an external resource (not hosted on the website or on the GitHub repository).<br>
 <em><strong>Good study 🤓</strong></em></p>
 <p> </p>
 <hr>

--- a/public/index.xml
+++ b/public/index.xml
@@ -35,11 +35,9 @@ In generale, il materiale prodotto dall&amp;rsquo;autore e presente nella raccol
       
       <guid>/contact/</guid>
       <description>Support 🇮🇹 Condividi eventuali problemi col sito o tue idee.
-Puoi farlo via email qui sotto o via Github.
-Qui sotto puoi anche mandare direttamente i tuoi appunti.
+Puoi farlo via email qui sotto o via Github. Qui sotto puoi anche mandare direttamente i tuoi appunti.
 🇬🇧 Feel free to share any issues with the website or your ideas.
-You can do it down below or open an issue on Github.
-Down below you can also send your notes directly.
+You can do it down below or open an issue on Github. Down below you can also send your notes directly.
 E-mail us Name&amp;nbsp;E-mail address&amp;nbsp;Message&amp;nbsp;SubmitYou need Javascript for CAPTCHA verification to submit this form.</description>
     </item>
     
@@ -49,7 +47,7 @@ E-mail us Name&amp;nbsp;E-mail address&amp;nbsp;Message&amp;nbsp;SubmitYo
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>/report-a-copyright-violation/</guid>
-      <description>🇬🇧 Report a copyright violation You have two options for reporting copyright violations:
+      <description>🇬🇧 Report a copyright violation copyright: violationcopyrightcopyrightviolationviolationYou have two options for reporting copyright violations:
 Guided Report Issue on GitHub: If you have a GitHub account, you can report copyright violations using our guided reporting issue on GitHub. This system is designed to help you provide the minimum necessary information effectively.
 Via Email: You can also report violations by sending us an email. Please refer to our contact page to reach us.</description>
     </item>

--- a/public/licenses/index.html
+++ b/public/licenses/index.html
@@ -39,7 +39,7 @@ In generale, il materiale prodotto dall&rsquo;autore e presente nella raccolta e
 In generale, il materiale prodotto dall&rsquo;autore e presente nella raccolta ed è da intendersi rilasciato sotto licenza Creative Commons BY-NC-SA 4.0.
 🇬🇧 The material present in this page has been prepared by the author or contributed to this collection by the respective authors, except for the resources marked by (*).">
 
-<meta itemprop="wordCount" content="187">
+<meta itemprop="wordCount" content="189">
 <meta itemprop="keywords" content="" />
 <meta name="referrer" content="no-referrer-when-downgrade" />
 
@@ -111,6 +111,7 @@ In generale, il materiale prodotto dall&rsquo;autore e presente nella raccolta e
 <p>🇬🇧  The material present in this page has been prepared by the <a href="https://github.com/valerionew">author</a> or contributed to this collection by the respective authors, except for the resources marked by <strong>(*)</strong>.<br>
 In general, except otherwise specified, the author&rsquo;s material and the other right owner&rsquo;s contributions are released under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons BY-NC-SA 4.0 license</a>.</p>
 <hr>
+<h3 id="external-links">External links</h3>
 <p>🇮🇹  <strong>(*)</strong>: indica il materiale liberamente disponibile in rete riportato su questa risorsa. Dove lo si è ritenuto opportuno, si è provveduto a creare una copia locale, nel caso le risorse diventassero non più disponibili in futuro. <strong>Tutti i diritti restano dei rispettivi autori.</strong></p>
 <p>🇬🇧  <strong>(*)</strong>: marks the material freely available on internet, reported in this resource. Where it was deemed appropriate, we proceeded to create a local mirror, in case the resource stops beeing available in the future. <strong>All the rights remain to the respective authors.</strong></p>
 <p> </p>

--- a/public/report-a-copyright-violation/index.html
+++ b/public/report-a-copyright-violation/index.html
@@ -9,14 +9,14 @@
 <link rel="shortcut icon" href="/favicon.ico" />
 <title>Report a copyright violation | Electronics engineering at Polimi 📝</title>
 <meta name="title" content="Report a copyright violation" />
-<meta name="description" content="🇬🇧 Report a copyright violation You have two options for reporting copyright violations:
+<meta name="description" content="🇬🇧 Report a copyright violation copyright: violationcopyrightcopyrightviolationviolationYou have two options for reporting copyright violations:
 Guided Report Issue on GitHub: If you have a GitHub account, you can report copyright violations using our guided reporting issue on GitHub. This system is designed to help you provide the minimum necessary information effectively.
 Via Email: You can also report violations by sending us an email. Please refer to our contact page to reach us." />
 <meta name="keywords" content="" />
 
 
 <meta property="og:title" content="Report a copyright violation" />
-<meta property="og:description" content="🇬🇧 Report a copyright violation You have two options for reporting copyright violations:
+<meta property="og:description" content="🇬🇧 Report a copyright violation copyright: violationcopyrightcopyrightviolationviolationYou have two options for reporting copyright violations:
 Guided Report Issue on GitHub: If you have a GitHub account, you can report copyright violations using our guided reporting issue on GitHub. This system is designed to help you provide the minimum necessary information effectively.
 Via Email: You can also report violations by sending us an email. Please refer to our contact page to reach us." />
 <meta property="og:type" content="article" />
@@ -28,18 +28,18 @@ Via Email: You can also report violations by sending us an email. Please refer t
 
 <meta name="twitter:card" content="summary"/>
 <meta name="twitter:title" content="Report a copyright violation"/>
-<meta name="twitter:description" content="🇬🇧 Report a copyright violation You have two options for reporting copyright violations:
+<meta name="twitter:description" content="🇬🇧 Report a copyright violation copyright: violationcopyrightcopyrightviolationviolationYou have two options for reporting copyright violations:
 Guided Report Issue on GitHub: If you have a GitHub account, you can report copyright violations using our guided reporting issue on GitHub. This system is designed to help you provide the minimum necessary information effectively.
 Via Email: You can also report violations by sending us an email. Please refer to our contact page to reach us."/>
 
 
 
 <meta itemprop="name" content="Report a copyright violation">
-<meta itemprop="description" content="🇬🇧 Report a copyright violation You have two options for reporting copyright violations:
+<meta itemprop="description" content="🇬🇧 Report a copyright violation copyright: violationcopyrightcopyrightviolationviolationYou have two options for reporting copyright violations:
 Guided Report Issue on GitHub: If you have a GitHub account, you can report copyright violations using our guided reporting issue on GitHub. This system is designed to help you provide the minimum necessary information effectively.
 Via Email: You can also report violations by sending us an email. Please refer to our contact page to reach us.">
 
-<meta itemprop="wordCount" content="125">
+<meta itemprop="wordCount" content="131">
 <meta itemprop="keywords" content="" />
 <meta name="referrer" content="no-referrer-when-downgrade" />
 
@@ -106,7 +106,65 @@ Via Email: You can also report violations by sending us an email. Please refer t
 <content>
   <hr>
 <h2 id="-nbspreport-a-copyright-violation">🇬🇧  Report a copyright violation</h2>
-<p><a href="https://github.com/valerionew/triennale-elettronica-polimi/issues/new?assignees=&amp;labels=Copyright&amp;template=report-violazione-di-copyright.md"><img src="https://img.shields.io/badge/copyright-violation-red?style=flat" alt="Copyright violation"></a></p>
+<p><a href="https://github.com/valerionew/triennale-elettronica-polimi/issues/new?assignees=&amp;labels=Copyright&amp;template=report-violazione-di-copyright.md"><svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  width="118"
+  height="20"
+  role="img"
+  aria-label="copyright: violation"
+>
+  <title>copyright: violation</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+    <stop offset="1" stop-opacity=".1" />
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="118" height="20" rx="3" fill="#fff" />
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="61" height="20" fill="#555" />
+    <rect x="61" width="57" height="20" fill="#e05d44" />
+    <rect width="118" height="20" fill="url(#s)" />
+  </g>
+  <g
+    fill="#fff"
+    text-anchor="middle"
+    font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+    text-rendering="geometricPrecision"
+    font-size="110"
+  >
+    <text
+      aria-hidden="true"
+      x="315"
+      y="150"
+      fill="#010101"
+      fill-opacity=".3"
+      transform="scale(.1)"
+      textLength="510"
+    >
+      copyright
+    </text>
+    <text x="315" y="140" transform="scale(.1)" fill="#fff" textLength="510">
+      copyright
+    </text>
+    <text
+      aria-hidden="true"
+      x="885"
+      y="150"
+      fill="#010101"
+      fill-opacity=".3"
+      transform="scale(.1)"
+      textLength="470"
+    >
+      violation
+    </text>
+    <text x="885" y="140" transform="scale(.1)" fill="#fff" textLength="470">
+      violation
+    </text>
+  </g>
+</svg>
+</a></p>
 <p>You have two options for reporting copyright violations:</p>
 <ol>
 <li>


### PR DESCRIPTION
- Added **(\*)** to notes (external links) added by me (my bad, sorry).
- Added links to Licenses section on the first page in Extra to explain what purpose **(\*)** serve.
- Added `svg` for copyright to ease the load of the page.
- Added the ability to switch between Netlify Mirror and Github Page directly from the support section, to help end user in case of host platform's down.
- Updated Hugo to latest version.
- Updated public folder's `html`
- No new material added
